### PR TITLE
Allow hash2ini to write numerics or booleans as is

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,9 +167,11 @@ probably want
 
 It accepts the following optional parameters passed to it in a hash as the second argument:
 
-* `header`: String you want at the top of the file saying it is controlled by puppet. Default: '# THIS FILE IS CONTROLLED BY PUPPET'
+* `header`: String you want at the top of the file saying it is controlled by puppet. Default: '# THIS FILE IS CONTROLLED BY PUPPET'.
 * `key_val_separator`: String to use between setting name and value (e.g., to determine whether the separator includes whitespace). Default: '='.
-* `quote_char`: Character or string to quote the entire value of the setting. Default: '"'
+* `quote_char`: Character or string to quote the entire value of the setting. Default: '"'.
+* `quote_booleans`: A boolean controlling whether or not to quote boolean values. Default: 'true'.
+* `quote_numerics`: A boolean controlling whether or not to quote numeric values. Default: 'true'.
 
 For example:
 

--- a/lib/puppet/parser/functions/hash2ini.rb
+++ b/lib/puppet/parser/functions/hash2ini.rb
@@ -22,6 +22,8 @@ This converts a puppet hash to an INI string.
       'section_suffix'    => ']',
       'key_val_separator' => '=',
       'quote_char'        => '"',
+      "quote_booleans"    => true,
+      "quote_numerics"    => true,
     }
 
     if arguments[1]
@@ -38,7 +40,13 @@ This converts a puppet hash to an INI string.
     h.keys.each do |section|
       ini << "#{settings['section_prefix']}#{section}#{settings['section_suffix']}"
       h[section].each do |k, v|
-        ini << "#{k}#{settings['key_val_separator']}#{settings['quote_char']}#{v}#{settings['quote_char']}"
+        v_is_a_boolean = (v.is_a?(TrueClass) or v.is_a?(FalseClass))
+
+        if (v_is_a_boolean and not settings['quote_booleans']) or (v.is_a?(Numeric) and not settings['quote_numerics'])
+          ini << "#{k}#{settings['key_val_separator']}#{v}"
+        else
+          ini << "#{k}#{settings['key_val_separator']}#{settings['quote_char']}#{v}#{settings['quote_char']}"
+        end
       end
       ini << nil
     end

--- a/spec/functions/hash2ini_spec.rb
+++ b/spec/functions/hash2ini_spec.rb
@@ -18,7 +18,7 @@ describe 'hash2ini' do
     }
   }
 
-  context 'no custom settings' do
+  context 'default settings' do
     output=<<-EOS
 # THIS FILE IS CONTROLLED BY PUPPET
 
@@ -54,6 +54,28 @@ awesome: true
 logging: DEBUG
 log_location: /var/log/dev.log
 EOS
+    it { is_expected.to run.with_params(example_input, settings).and_return(output) }
+  end
+
+
+  context 'default settings with custom quoting' do
+    settings = {
+      'quote_booleans' => false,
+      'quote_numerics' => false,
+    }
+    output=<<-EOS
+# THIS FILE IS CONTROLLED BY PUPPET
+
+[main]
+logging="INFO"
+limit=314
+awesome=true
+
+[dev]
+logging="DEBUG"
+log_location="/var/log/dev.log"
+EOS
+
     it { is_expected.to run.with_params(example_input, settings).and_return(output) }
   end
 end


### PR DESCRIPTION
I'd like to use `hash2ini` to generate [telegraf agent configuration](https://github.com/influxdata/telegraf/blob/master/etc/telegraf.conf) (that in fact use TOML and no INI).

For doing this, I need to quote every values but numeric or boolean ones (`telegraf` would exit with an error if I did quote those values).